### PR TITLE
Edit terms translations

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -40,7 +40,7 @@ service cloud.firestore {
 
     match /users/{user} {
       allow get: if isUser(user) || isAdmin();
-      allow list: if isAdmin(); 
+      allow list: if isAdmin();
     }
 
     function isValidUserSettings() {
@@ -52,7 +52,7 @@ service cloud.firestore {
 
     match /userSettings/{user} {
       allow get: if isUser(user) || isAdmin();
-      allow list: if isAdmin(); 
+      allow list: if isAdmin();
       allow create, update: if isValidatedUser() && isUser(user) && isValidUserSettings();
     }
 
@@ -74,9 +74,17 @@ service cloud.firestore {
         data.commentCount == 0;
     }
 
+    function isValidTermUpdate() {
+      let data = request.resource.data;
+      return data.diff(resource.data).affectedKeys().hasOnly(['value', 'lang']) &&
+        data.value is string &&
+        data.lang is string;
+    }
+
     match /terms/{term} {
       allow read: if true;
       allow create: if isValidatedUser() && isCreator() && isValidTerm();
+      allow update: if isValidatedUser() && (isCreator() || isAdmin()) && isValidTermUpdate();
     }
 
     function isValidTranslation() {

--- a/firestore.rules
+++ b/firestore.rules
@@ -64,9 +64,10 @@ service cloud.firestore {
 
     function isValidTerm() {
       let data = request.resource.data;
-      return data.keys().hasOnly(['creator', 'createdAt', 'weekHighlight', 'value', 'variants', 'lang', 'relatedTerms', 'commentCount']) &&
+      return data.keys().hasOnly(['creator', 'createdAt', 'weekHighlight', 'adminComment', 'value', 'variants', 'lang', 'relatedTerms', 'commentCount']) &&
         data.createdAt == request.time &&
         data.weekHighlight == false &&
+        data.adminComment == '' &&
         data.value is string &&
         data.variants is list &&
         data.lang is string &&
@@ -86,7 +87,6 @@ service cloud.firestore {
       return data.diff(resource.data).affectedKeys().hasOnly(['value', 'lang', 'adminComment', 'weekHighlight']) &&
         data.value is string &&
         data.lang is string &&
-        data.adminComment is string &&
         data.weekHighlight is bool;
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -109,9 +109,16 @@ service cloud.firestore {
         data.commentCount == 0;
     }
 
+    function isValidTranslationUpdate() {
+      let data = request.resource.data;
+      return data.diff(resource.data).affectedKeys().hasOnly(['value']) &&
+        data.value is string;
+    }
+
     match /translations/{translation} {
       allow read: if true;
       allow create: if isValidatedUser() && isCreator() && isValidTranslation();
+      allow update: if isValidatedUser() && (isCreator() || isAdmin()) && isValidTranslationUpdate();
 
       function isValidRating() {
         let data = request.resource.data;

--- a/firestore.rules
+++ b/firestore.rules
@@ -81,10 +81,20 @@ service cloud.firestore {
         data.lang is string;
     }
 
+    function isValidTermUpdateAdmin() {
+      let data = request.resource.data;
+      return data.diff(resource.data).affectedKeys().hasOnly(['value', 'lang', 'adminComment', 'weekHighlight']) &&
+        data.value is string &&
+        data.lang is string &&
+        data.adminComment is string &&
+        data.weekHighlight is bool;
+    }
+
     match /terms/{term} {
       allow read: if true;
       allow create: if isValidatedUser() && isCreator() && isValidTerm();
-      allow update: if isValidatedUser() && (isCreator() || isAdmin()) && isValidTermUpdate();
+      allow update: if isValidatedUser() &&
+        ((isAdmin() && isValidTermUpdateAdmin()) || (isCreator() && isValidTermUpdate()));
     }
 
     function isValidTranslation() {

--- a/firestore.rules
+++ b/firestore.rules
@@ -95,6 +95,7 @@ service cloud.firestore {
       allow create: if isValidatedUser() && isCreator() && isValidTerm();
       allow update: if isValidatedUser() &&
         ((isAdmin() && isValidTermUpdateAdmin()) || (isCreator() && isValidTermUpdate()));
+      allow delete: if isValidatedUser() && isAdmin();
     }
 
     function isValidTranslation() {

--- a/firestore.rules
+++ b/firestore.rules
@@ -100,13 +100,14 @@ service cloud.firestore {
 
     function isValidTranslation() {
       let data = request.resource.data;
-      return data.keys().hasOnly(['term', 'creator', 'createdAt', 'value', 'variants', 'lang', 'relatedTerms', 'commentCount']) &&
+      return data.keys().hasOnly(['term', 'creator', 'createdAt', 'value', 'variants', 'lang', 'relatedTerms', 'commentCount', 'ratings']) &&
         data.term is path &&
         data.createdAt == request.time &&
         data.value is string &&
         data.variants is list &&
         data.lang is string &&
-        data.commentCount == 0;
+        data.commentCount == 0 &&
+        data.ratings == null;
     }
 
     function isValidTranslationUpdate() {

--- a/firestore.rules
+++ b/firestore.rules
@@ -119,6 +119,7 @@ service cloud.firestore {
       allow read: if true;
       allow create: if isValidatedUser() && isCreator() && isValidTranslation();
       allow update: if isValidatedUser() && (isCreator() || isAdmin()) && isValidTranslationUpdate();
+      allow delete: if isValidatedUser() && isAdmin();
 
       function isValidRating() {
         let data = request.resource.data;

--- a/src/AdminPage/index.tsx
+++ b/src/AdminPage/index.tsx
@@ -28,6 +28,7 @@ const useAuthUserInfos = () => {
 };
 
 const ensureValidUserEntities = () => functions.httpsCallable('userManagement-ensureValidUserEntities')();
+const runContentMigrations = () => functions.httpsCallable('userManagement-runContentMigrations')();
 
 const deleteAllContentOfUser = (userId: string) => {
     const fn = functions.httpsCallable('userManagement-deleteAllContentOfUser');
@@ -72,7 +73,10 @@ function UserList() {
 
             <SingleColumn>
                 <ColumnHeading>Data Migrations</ColumnHeading>
-                <EnsureValidUserEntitiesButton />
+                <ButtonContainer align="left">
+                    <EnsureValidUserEntitiesButton />
+                    <RunContentMigrationsButton />
+                </ButtonContainer>
             </SingleColumn>
         </>
     );
@@ -250,6 +254,31 @@ function EnsureValidUserEntitiesButton() {
             {onClick => (
                 <Button disabled={requestState === 'IN_PROGRESS' || requestState === 'DONE'} onClick={onClick}>
                     {requestState === 'DONE' ? 'Ensured Valid User Entities' : 'Ensure Valid User Entities'}
+                </Button>
+            )}
+        </ConfirmModal>
+    );
+}
+
+function RunContentMigrationsButton() {
+    const [requestState, setRequestState] = useRequestState();
+    const onConfirm = useCallback(() => {
+        setRequestState('IN_PROGRESS');
+        runContentMigrations().then(
+            () => setRequestState('DONE'),
+            error => setRequestState('ERROR', error)
+        );
+    }, [setRequestState]);
+    return (
+        <ConfirmModal
+            title="Run Content Migrations?"
+            body={<p>This will add defaults for newly added fields to content entites.</p>}
+            confirmLabel="Run"
+            onConfirm={onConfirm}
+        >
+            {onClick => (
+                <Button disabled={requestState === 'IN_PROGRESS' || requestState === 'DONE'} onClick={onClick}>
+                    {requestState === 'DONE' ? 'Ran Content Migrations' : 'Run Content Migrations'}
                 </Button>
             )}
         </ConfirmModal>

--- a/src/Rating/RatingWidget/index.tsx
+++ b/src/Rating/RatingWidget/index.tsx
@@ -17,8 +17,8 @@ import s from './style.module.css';
 
 type Sizes = 'small' | 'medium' | 'large';
 
-type RatingDisplayProps = {
-    ratings?: number[];
+type Props = {
+    ratings: number[] | null;
     termLang: Lang;
     termValue: string;
     translationValue: string;
@@ -27,14 +27,28 @@ type RatingDisplayProps = {
     size?: Sizes;
 };
 
-export function RatingWidget(props: RatingDisplayProps) {
+type DisplayProps = {
+    ratings?: number[];
+    termValue: string;
+    rangeInputProps?: React.InputHTMLAttributes<any>;
+    size?: Sizes;
+};
+
+export function RatingWidget(props: Props) {
     const { t } = useTranslation();
     const [overlayOpen, setOverlayOpen] = useState(false);
     const unset = !props.rangeInputProps?.value;
 
+    const displayProps: DisplayProps = {
+        ratings: props.ratings ?? undefined,
+        termValue: props.termValue,
+        rangeInputProps: props.rangeInputProps,
+        size: props.size,
+    };
+
     return (
         <div className={s.unsetButtonContainer}>
-            <RatingDisplay {...props} />
+            <RatingDisplay {...displayProps} />
             {unset && props.size !== 'small' && (
                 <button onClick={() => setOverlayOpen(true)} className={s.unsetButton}>
                     {t('rating.clickToSet')}
@@ -60,7 +74,7 @@ export function RatingWidget(props: RatingDisplayProps) {
                 >
                     <p>{t('rating.dragToSet')}</p>
                     <div className={getDominantLanguageClass(props.translationLang)}>
-                        <RatingDisplay {...props} size="large" />
+                        <RatingDisplay {...displayProps} size="large" />
                     </div>
                     <ButtonContainer>
                         <Button onClick={() => setOverlayOpen(false)} style={{ marginTop: 10 }}>
@@ -78,7 +92,7 @@ function RatingDisplay({
     termValue,
     rangeInputProps,
     size = 'medium',
-}: RatingDisplayProps) {
+}: DisplayProps) {
     const max = Math.max(...ratings);
     const { t } = useTranslation();
     const [globalLang] = useLang();
@@ -203,16 +217,7 @@ export function RatingWidgetContainer({ translation, term, size }: RatingWidgetC
         );
     }
 
-    return (
-        <RatingDisplay
-            size={size}
-            ratings={translation.ratings}
-            translationLang={translation.lang}
-            translationValue={translationValue}
-            termValue={termValue}
-            termLang={term.lang}
-        />
-    );
+    return <RatingDisplay size={size} ratings={translation.ratings ?? undefined} termValue={termValue} />;
 }
 
 function RatingWidgetLoggedIn({
@@ -242,11 +247,8 @@ function RatingWidgetLoggedIn({
 
     return (
         <RatingDisplay
-            ratings={translation.ratings}
+            ratings={translation.ratings ?? undefined}
             termValue={termValue}
-            termLang={term.lang}
-            translationValue={translationValue}
-            translationLang={translation.lang}
             rangeInputProps={rangeInputProps}
             size={size}
         />

--- a/src/TermPage/index.tsx
+++ b/src/TermPage/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import Comments from '../Comments';
 import ConfirmModal from '../ConfirmModal';
 import Button, { ButtonContainer } from '../Form/Button';
@@ -95,25 +95,13 @@ export default function TermPage() {
 
 function DeleteTerm({ term }: { term: Term }) {
     const { t } = useTranslation();
-    const history = useHistory();
 
     return (
         <ConfirmModal
             title={t('term.deleteHeading')}
             body={<p>{t('term.deleteExplanation')}</p>}
             confirmLabel={t('common.formNav.delete')}
-            onConfirm={() => {
-                history.push('/');
-                collections.terms
-                    .doc(term.id)
-                    .delete()
-                    .then(() => {
-                        alert('Term deleted');
-                    })
-                    .catch(error => {
-                        alert('Something went wrong: ' + error);
-                    });
-            }}
+            onConfirm={() => collections.terms.doc(term.id).delete()}
         >
             {onClick => <LinkButton onClick={onClick}>{t('common.formNav.delete')}</LinkButton>}
         </ConfirmModal>

--- a/src/TermPage/index.tsx
+++ b/src/TermPage/index.tsx
@@ -1,13 +1,22 @@
+import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import Comments from '../Comments';
+import Button, { ButtonContainer } from '../Form/Button';
+import { Input, Select } from '../Form/Input';
+import InputContainer from '../Form/InputContainer';
 import { FormatDate } from '../FormatDate';
 import Header from '../Header';
+import { useAppContext } from '../hooks/appContext';
 import { collections, useTerm } from '../hooks/data';
+import { langA, langB } from '../languages';
 import { FullWidthColumn, SingleColumn } from '../Layout/Columns';
+import LinkButton from '../LinkButton';
+import { ModalDialog } from '../ModalDialog';
 import { Redact, useRedacted } from '../RedactSensitiveTerms';
 import { TermWithLang } from '../TermWithLang';
 import { TranslationsList } from '../TranslationsList';
+import { Lang, Term } from '../types';
 import { getDominantLanguageClass } from '../useLangCssVars';
 
 export default function TermPage() {
@@ -21,14 +30,17 @@ export default function TermPage() {
             <Header
                 capitalize
                 subLine={
-                    <Trans
-                        t={t}
-                        i18nKey="common.addedOn"
-                        components={{
-                            User: term.creator.displayName,
-                            FormatDate: <FormatDate date={term.createdAt} />,
-                        }}
-                    />
+                    <>
+                        <Trans
+                            t={t}
+                            i18nKey="common.addedOn"
+                            components={{
+                                User: term.creator.displayName,
+                                FormatDate: <FormatDate date={term.createdAt} />,
+                            }}
+                        />
+                        <EditTerm term={term} />
+                    </>
                 }
                 mainLang={term.lang}
             >
@@ -55,5 +67,88 @@ export default function TermPage() {
                 </div>
             </SingleColumn>
         </>
+    );
+}
+
+function EditTerm({ term }: { term: Term }) {
+    const { user, userProperties } = useAppContext();
+    const [editOpen, setEditOpen] = useState(false);
+    const { t } = useTranslation();
+    const canEdit = term.creator.id === user?.id || userProperties?.admin;
+
+    if (!canEdit) {
+        return null;
+    }
+
+    return (
+        <div>
+            <LinkButton
+                onClick={() => {
+                    setEditOpen(true);
+                }}
+            >
+                {t('common.entities.term.edit')}
+            </LinkButton>
+            {editOpen && (
+                <EditTermOverlay
+                    term={term}
+                    onClose={() => {
+                        setEditOpen(false);
+                    }}
+                />
+            )}
+        </div>
+    );
+}
+
+function EditTermOverlay({ term, onClose }: { term: Term; onClose: () => void }) {
+    const { t } = useTranslation();
+    const [saving, setIsSaving] = useState(false);
+    const [value, setValue] = useState(term.value);
+    const [lang, setLang] = useState<Lang>(term.lang);
+
+    const onSave = () => {
+        setIsSaving(true);
+        collections.terms
+            .doc(term.id)
+            .set({ ...term, value, lang })
+            .then(() => {
+                setIsSaving(false);
+                onClose();
+            });
+    };
+
+    return (
+        <ModalDialog title={t('common.entities.term.edit')} onClose={onClose}>
+            {saving ? (
+                <>{t('common.saving')}</>
+            ) : (
+                <>
+                    <InputContainer>
+                        <Input
+                            label={t('common.entities.term.value')}
+                            span={3}
+                            value={value}
+                            onChange={({ target: { value } }) => setValue(value)}
+                        />
+                        <Select
+                            label={t('common.langLabels.language')}
+                            span={1}
+                            value={lang}
+                            onChange={({ target: { value } }) => setLang(value as Lang)}
+                        >
+                            <option value={langA}>{t(`common.langLabels.${langA}` as const)}</option>
+                            <option value={langB}>{t(`common.langLabels.${langB}` as const)}</option>
+                        </Select>
+                    </InputContainer>
+                    <ButtonContainer>
+                        <Button onClick={onClose}>{t('common.formNav.cancel')}</Button>
+                        <Button onClick={onSave} primary>
+                            {t('common.formNav.save')}
+                        </Button>
+                    </ButtonContainer>
+                </>
+            )}
+        </ModalDialog>
     );
 }

--- a/src/TermPage/style.module.css
+++ b/src/TermPage/style.module.css
@@ -1,0 +1,5 @@
+.adminComment {
+    font-family: var(--paragraphFont);
+    line-height: var(--lineHeightParagraph);
+    white-space: pre-wrap;
+}

--- a/src/TranslationPage/index.tsx
+++ b/src/TranslationPage/index.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { generatePath, useParams } from 'react-router-dom';
+import { generatePath, useHistory, useParams } from 'react-router-dom';
+import ConfirmModal from '../ConfirmModal';
 import Button, { ButtonContainer } from '../Form/Button';
 import { Input } from '../Form/Input';
 import InputContainer from '../Form/InputContainer';
@@ -28,6 +29,7 @@ export function TranslationPage() {
     const term = useTerm(termId);
     const translation = useTranslationEntity(translationId);
     const canEdit = translation.creator.id === user?.id || userProperties?.admin;
+    const canDelete = userProperties?.admin;
 
     return (
         <>
@@ -51,11 +53,16 @@ export function TranslationPage() {
                                 FormatDate: <FormatDate date={translation.createdAt} />,
                             }}
                         />
-
                         {canEdit && (
                             <>
                                 {' | '}
                                 <EditTranslation translation={translation} />
+                            </>
+                        )}
+                        {canDelete && (
+                            <>
+                                {' | '}
+                                <DeleteTranslation translation={translation} />
                             </>
                         )}
                     </>
@@ -88,6 +95,33 @@ export function TranslationPage() {
 
             <TranslationExamplesList term={term} translation={translation} />
         </>
+    );
+}
+
+function DeleteTranslation({ translation }: { translation: Translation }) {
+    const { t } = useTranslation();
+    const history = useHistory();
+
+    return (
+        <ConfirmModal
+            title={t('translation.deleteHeading')}
+            body={<p>{t('translation.deleteExplanation')}</p>}
+            confirmLabel={t('common.formNav.delete')}
+            onConfirm={() => {
+                history.push('/');
+                collections.translations
+                    .doc(translation.id)
+                    .delete()
+                    .then(() => {
+                        alert('Translation deleted');
+                    })
+                    .catch(error => {
+                        alert('Something went wrong: ' + error);
+                    });
+            }}
+        >
+            {onClick => <LinkButton onClick={onClick}>{t('common.formNav.delete')}</LinkButton>}
+        </ConfirmModal>
     );
 }
 

--- a/src/TranslationPage/index.tsx
+++ b/src/TranslationPage/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { generatePath, useHistory, useParams } from 'react-router-dom';
+import { generatePath, useParams } from 'react-router-dom';
 import ConfirmModal from '../ConfirmModal';
 import Button, { ButtonContainer } from '../Form/Button';
 import { Input } from '../Form/Input';
@@ -100,25 +100,13 @@ export function TranslationPage() {
 
 function DeleteTranslation({ translation }: { translation: Translation }) {
     const { t } = useTranslation();
-    const history = useHistory();
 
     return (
         <ConfirmModal
             title={t('translation.deleteHeading')}
             body={<p>{t('translation.deleteExplanation')}</p>}
             confirmLabel={t('common.formNav.delete')}
-            onConfirm={() => {
-                history.push('/');
-                collections.translations
-                    .doc(translation.id)
-                    .delete()
-                    .then(() => {
-                        alert('Translation deleted');
-                    })
-                    .catch(error => {
-                        alert('Something went wrong: ' + error);
-                    });
-            }}
+            onConfirm={() => collections.translations.doc(translation.id).delete()}
         >
             {onClick => <LinkButton onClick={onClick}>{t('common.formNav.delete')}</LinkButton>}
         </ConfirmModal>

--- a/src/TranslationPage/index.tsx
+++ b/src/TranslationPage/index.tsx
@@ -1,23 +1,33 @@
 import clsx from 'clsx';
+import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { generatePath, useParams } from 'react-router-dom';
+import Button, { ButtonContainer } from '../Form/Button';
+import { Input } from '../Form/Input';
+import InputContainer from '../Form/InputContainer';
 import { FormatDate } from '../FormatDate';
 import Header from '../Header';
-import { useTerm, useTranslationEntity } from '../hooks/data';
+import { useAppContext } from '../hooks/appContext';
+import { collections, useTerm, useTranslationEntity } from '../hooks/data';
 import { ColumnHeading, SingleColumn } from '../Layout/Columns';
+import LinkButton from '../LinkButton';
+import { ModalDialog } from '../ModalDialog';
 import { RatingWidgetContainer } from '../Rating/RatingWidget';
 import { Redact } from '../RedactSensitiveTerms';
 import { TERM } from '../routes';
 import { WrappedInLangColor } from '../TermWithLang';
 import TranslationExamplesList from '../TranslationExamplesList';
+import { Translation } from '../types';
 import { getDominantLanguageClass } from '../useLangCssVars';
 import s from './style.module.css';
 
 export function TranslationPage() {
+    const { user, userProperties } = useAppContext();
     const { t } = useTranslation();
     const { termId, translationId } = useParams<{ termId: string; translationId: string }>();
     const term = useTerm(termId);
     const translation = useTranslationEntity(translationId);
+    const canEdit = translation.creator.id === user?.id || userProperties?.admin;
 
     return (
         <>
@@ -32,14 +42,23 @@ export function TranslationPage() {
                     },
                 ]}
                 subLine={
-                    <Trans
-                        t={t}
-                        i18nKey="common.addedOn"
-                        components={{
-                            User: translation.creator.displayName,
-                            FormatDate: <FormatDate date={translation.createdAt} />,
-                        }}
-                    />
+                    <>
+                        <Trans
+                            t={t}
+                            i18nKey="common.addedOn"
+                            components={{
+                                User: translation.creator.displayName,
+                                FormatDate: <FormatDate date={translation.createdAt} />,
+                            }}
+                        />
+
+                        {canEdit && (
+                            <>
+                                {' | '}
+                                <EditTranslation translation={translation} />
+                            </>
+                        )}
+                    </>
                 }
             >
                 <Redact>{translation.value}</Redact>
@@ -69,5 +88,72 @@ export function TranslationPage() {
 
             <TranslationExamplesList term={term} translation={translation} />
         </>
+    );
+}
+
+function EditTranslation({ translation }: { translation: Translation }) {
+    const [editOpen, setEditOpen] = useState(false);
+    const { t } = useTranslation();
+
+    return (
+        <>
+            <LinkButton
+                onClick={() => {
+                    setEditOpen(true);
+                }}
+            >
+                {t('common.entities.translation.edit')}
+            </LinkButton>
+            {editOpen && (
+                <EditTranslationOverlay
+                    translation={translation}
+                    onClose={() => {
+                        setEditOpen(false);
+                    }}
+                />
+            )}
+        </>
+    );
+}
+
+function EditTranslationOverlay({ translation, onClose }: { translation: Translation; onClose: () => void }) {
+    const { t } = useTranslation();
+    const [saving, setIsSaving] = useState(false);
+    const [value, setValue] = useState(translation.value);
+
+    const onSave = () => {
+        setIsSaving(true);
+        collections.translations
+            .doc(translation.id)
+            .set({ ...translation, value })
+            .then(() => {
+                setIsSaving(false);
+                onClose();
+            });
+    };
+
+    return (
+        <ModalDialog title={t('common.entities.translation.edit')} onClose={onClose}>
+            {saving ? (
+                <>{t('common.saving')}</>
+            ) : (
+                <>
+                    <InputContainer>
+                        <Input
+                            label={t('common.entities.translation.value')}
+                            value={value}
+                            onChange={({ target: { value } }) => setValue(value)}
+                        />
+                    </InputContainer>
+
+                    <ButtonContainer>
+                        <Button onClick={onClose}>{t('common.formNav.cancel')}</Button>
+                        <Button onClick={onSave} primary>
+                            {t('common.formNav.save')}
+                        </Button>
+                    </ButtonContainer>
+                </>
+            )}
+        </ModalDialog>
     );
 }

--- a/src/TranslationsList/index.tsx
+++ b/src/TranslationsList/index.tsx
@@ -170,7 +170,11 @@ function AddExampleButton({ to, className }: { to: string; className?: string })
     );
 }
 
-function averageRatings(ratings: number[] = []) {
+function averageRatings(ratings: number[] | null) {
+    if (!ratings) {
+        return 0;
+    }
+
     const sumOfAllRatings = ratings.reduce((accumulator, current, index) => {
         return accumulator + current * (index + 1);
     }, 0);

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -59,9 +59,17 @@ const TermConverter: firebase.firestore.FirestoreDataConverter<Term> = {
         return { ...data, createdAt: getCreatedAt(term) };
     },
     fromFirestore: (snapshot): Term => {
-        const { relatedTerms, creator, createdAt, value, variants, lang, commentCount, weekHighlight } = snapshot.data(
-            defaultSnapshotOptions
-        );
+        const {
+            relatedTerms,
+            creator,
+            createdAt,
+            value,
+            variants,
+            lang,
+            commentCount,
+            weekHighlight,
+            adminComment,
+        } = snapshot.data(defaultSnapshotOptions);
         return {
             id: snapshot.id,
             relatedTerms,
@@ -72,6 +80,7 @@ const TermConverter: firebase.firestore.FirestoreDataConverter<Term> = {
             lang,
             commentCount,
             weekHighlight,
+            adminComment,
         };
     },
 };

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -274,6 +274,7 @@ export async function addTranslation(user: User, term: Term, value: string, comm
         commentCount: 0,
         creator: { id: user.id, displayName: user.displayName },
         createdAt: firebase.firestore.Timestamp.now(),
+        ratings: null,
     });
 
     if (comment) {

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -242,6 +242,7 @@ export async function addTerm(user: User, value: string, lang: Lang, comment?: s
         value,
         commentCount: 0,
         weekHighlight: false,
+        adminComment: '',
         creator: { id: user.id, displayName: user.displayName },
         createdAt: firebase.firestore.Timestamp.now(),
     });

--- a/src/i18n/a/translation.json
+++ b/src/i18n/a/translation.json
@@ -127,7 +127,9 @@
             "en": "Add an English translation for: <Term />"
         },
         "addCommentHeading": "on how translate <Term />",
-        "commentPlaceholder": "...on how translate “{{term}}”"
+        "commentPlaceholder": "...on how translate “{{term}}”",
+        "deleteHeading": "Delete Term?",
+        "deleteExplanation": "Are you sure you want to delete this term? This cannot be undone!"
     },
     "translation": {
         "registerToAdd": "To add a translation, please <LoginLink>log in</LoginLink> or <SignUpLink>sign up</SignUpLink>.",

--- a/src/i18n/a/translation.json
+++ b/src/i18n/a/translation.json
@@ -136,7 +136,9 @@
         "registerToAdd": "To add a translation, please <LoginLink>log in</LoginLink> or <SignUpLink>sign up</SignUpLink>.",
         "empty": "There are no translations for <TermWithLang>{{term}}</TermWithLang> yet. Add one:",
         "emptyShort": "There are no translations yet",
-        "addTranslation": "Add a translation for <Term>{{term}}</Term> that you would like to discuss."
+        "addTranslation": "Add a translation for <Term>{{term}}</Term> that you would like to discuss.",
+        "deleteHeading": "Delete Translation?",
+        "deleteExplanation": "Are you sure you want to delete this translation? This cannot be undone!"
     },
     "mediaSearch": {
         "ariaDescription": "When results are available, use up and down arrow keys to select them. Press enter to confirm selection.",

--- a/src/i18n/a/translation.json
+++ b/src/i18n/a/translation.json
@@ -10,7 +10,8 @@
                 "value": "Term",
                 "value_plural": "Terms",
                 "add": "Add Term",
-                "all": "All Terms"
+                "all": "All Terms",
+                "edit": "Edit Term"
             },
             "translation": {
                 "value": "Translation",

--- a/src/i18n/a/translation.json
+++ b/src/i18n/a/translation.json
@@ -16,7 +16,8 @@
             "translation": {
                 "value": "Translation",
                 "value_plural": "Translations",
-                "add": "Add Translation"
+                "add": "Add Translation",
+                "edit": "Edit Translation"
             },
             "comment": {
                 "value": "Comment",

--- a/src/i18n/b/translation.json
+++ b/src/i18n/b/translation.json
@@ -16,7 +16,8 @@
             "translation": {
                 "value": "Übersetzung",
                 "value_plural": "Übersetzungen",
-                "add": "Übersetzung hinzufügen"
+                "add": "Übersetzung hinzufügen",
+                "edit": "Übersetzung bearbeiten"
             },
             "comment": {
                 "value": "Kommentar",

--- a/src/i18n/b/translation.json
+++ b/src/i18n/b/translation.json
@@ -10,7 +10,8 @@
                 "value": "Begriff",
                 "value_plural": "Begriffe",
                 "add": "Begriff hinzufügen",
-                "all": "Alle Begriffe"
+                "all": "Alle Begriffe",
+                "edit": "Begriff bearbeiten"
             },
             "translation": {
                 "value": "Übersetzung",

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,8 @@ export interface Term extends Commentable {
     relatedTerms: DocReference<Term>[];
     creator: UserMini;
     createdAt: Timestamp;
-    weekHighlight?: boolean;
-    adminComment?: string;
+    weekHighlight: boolean;
+    adminComment: string;
 
     value: string;
     variants: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface Term extends Commentable {
     creator: UserMini;
     createdAt: Timestamp;
     weekHighlight?: boolean;
+    adminComment?: string;
 
     value: string;
     variants: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface Translation extends Commentable {
     value: string;
     variants: string[];
     lang: Lang;
-    ratings?: number[];
+    ratings: number[] | null;
 }
 
 export type SourceType = 'BOOK' | 'WEBPAGE' | 'MOVIE';


### PR DESCRIPTION
adds:
* edit terms & translations by creators and admins
* delete terms & translations by admins
* add adminComment – a not for terms only editable by admins
* terms: admins can set / unset `weeklyHighlight`

not yet working: 

- [x] edit translations when there's no ratings yet
- [x] edit terms that have `adminComment` and `weeklyHighlight` not defined