### PR TITLE
Lodash: directly import methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,7 @@
                 "@react-aria/overlays": "3.7.2",
                 "@types/jest": "27.0.2",
                 "@types/linkify-it": "3.0.2",
-                "@types/lodash.debounce": "4.0.6",
-                "@types/lodash.deburr": "4.1.6",
-                "@types/lodash.escaperegexp": "4.1.6",
-                "@types/lodash.isequal": "4.5.5",
-                "@types/lodash.orderby": "4.6.6",
-                "@types/lodash.without": "4.4.6",
-                "@types/lodash.xor": "4.5.6",
+                "@types/lodash": "4.14.176",
                 "@types/mdx": "2.0.1",
                 "@types/mdx-js__react": "1.5.5",
                 "@types/node": "16.11.7",
@@ -33,19 +27,14 @@
                 "@types/webpack-env": "1.16.3",
                 "babel-loader": "8.1.0",
                 "clsx": "1.1.1",
+                "eslint-plugin-lodash": "7.3.0",
                 "eslint-plugin-mdx": "1.16.0",
                 "firebase": "9.4.1",
                 "firebase-tools": "9.22.0",
                 "i18next": "20.6.1",
                 "i18next-browser-languagedetector": "6.1.2",
                 "linkify-it": "3.0.3",
-                "lodash.debounce": "4.0.8",
-                "lodash.deburr": "4.1.0",
-                "lodash.escaperegexp": "4.1.2",
-                "lodash.isequal": "4.5.0",
-                "lodash.orderby": "4.6.0",
-                "lodash.without": "4.4.0",
-                "lodash.xor": "4.5.0",
+                "lodash": "4.17.21",
                 "prettier": "2.2.1",
                 "rc-tooltip": "5.1.1",
                 "react": "17.0.2",
@@ -4063,65 +4052,9 @@
             "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.168",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-            "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
-        },
-        "node_modules/@types/lodash.debounce": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
-            "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.deburr": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.deburr/-/lodash.deburr-4.1.6.tgz",
-            "integrity": "sha512-LsdZUIBM/YDQ4+w4/PSq2KTRRuCmBic48vzzKD7PHw1uIsKMWizwDtk0fMdqYmo9/iLMhHiFh2ol0eqhjT0VTg==",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.escaperegexp": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.escaperegexp/-/lodash.escaperegexp-4.1.6.tgz",
-            "integrity": "sha512-uENiqxLlqh6RzeE1cC6Z2gHqakToN9vKlTVCFkSVjAfeMeh2fY0916tHwJHeeKs28qB/hGYvKuampGYH5QDVCw==",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.isequal": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
-            "integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.orderby": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.orderby/-/lodash.orderby-4.6.6.tgz",
-            "integrity": "sha512-wQzu6xK+bSwhu45OeMI7fjywiIZiiaBzJB8W3fwnF1SJXHoOXRLutrSnVmq4yHPOM036qsy8lx9wHQcAbXNjJw==",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.without": {
-            "version": "4.4.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.without/-/lodash.without-4.4.6.tgz",
-            "integrity": "sha512-JkPlFMcerd1ZcPtVXTi9NZsFhRk7g/rlctGYxR+Bdp/5FxqFTeTa68eJuoeuifpcLCj9ASFSHuNf7kaq5Mu9iA==",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
-        "node_modules/@types/lodash.xor": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.xor/-/lodash.xor-4.5.6.tgz",
-            "integrity": "sha512-rD3zHQuR04SMUWEn6CHLGYNRHEFgakV4K9QhFFP/Ly5xdN2MWsy+gWFA4MxhY+sKKSSKjktjPVyBTo/6rUdTjA==",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
+            "version": "4.14.176",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+            "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
         },
         "node_modules/@types/long": {
             "version": "4.0.1",
@@ -9367,6 +9300,20 @@
             "version": "9.2.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
             "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug=="
+        },
+        "node_modules/eslint-plugin-lodash": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-7.3.0.tgz",
+            "integrity": "sha512-FQM8HklruJzulPawX3uZqWbeyN3bQT4hjVCpFYMrWo0Hdz1qDCwp1v3JS4zjhdssAXdwCxdnyrNMCZJK70GeUQ==",
+            "dependencies": {
+                "lodash": "^4.17.21"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": ">=2"
+            }
         },
         "node_modules/eslint-plugin-markdown": {
             "version": "2.2.1",
@@ -16190,16 +16137,6 @@
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
         },
-        "node_modules/lodash.debounce": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-        },
-        "node_modules/lodash.deburr": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-            "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s="
-        },
         "node_modules/lodash.defaults": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -16209,11 +16146,6 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
             "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-        },
-        "node_modules/lodash.escaperegexp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-            "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
         },
         "node_modules/lodash.flatten": {
             "version": "4.4.0",
@@ -16234,11 +16166,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-        },
-        "node_modules/lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
@@ -16287,11 +16214,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-        },
-        "node_modules/lodash.orderby": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.orderby/-/lodash.orderby-4.6.0.tgz",
-            "integrity": "sha1-5pfwTOXXhSL1TZM4syuBozk+TrM="
         },
         "node_modules/lodash.snakecase": {
             "version": "4.1.1",
@@ -16342,16 +16264,6 @@
             "dependencies": {
                 "lodash.keys": "~2.4.1"
             }
-        },
-        "node_modules/lodash.without": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-            "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
-        },
-        "node_modules/lodash.xor": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.xor/-/lodash.xor-4.5.0.tgz",
-            "integrity": "sha1-TUjtfpgJWwYyWCunFNP/iuj7HbY="
         },
         "node_modules/log-symbols": {
             "version": "2.2.0",
@@ -30243,65 +30155,9 @@
             "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
         },
         "@types/lodash": {
-            "version": "4.14.168",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-            "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
-        },
-        "@types/lodash.debounce": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
-            "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.deburr": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.deburr/-/lodash.deburr-4.1.6.tgz",
-            "integrity": "sha512-LsdZUIBM/YDQ4+w4/PSq2KTRRuCmBic48vzzKD7PHw1uIsKMWizwDtk0fMdqYmo9/iLMhHiFh2ol0eqhjT0VTg==",
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.escaperegexp": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.escaperegexp/-/lodash.escaperegexp-4.1.6.tgz",
-            "integrity": "sha512-uENiqxLlqh6RzeE1cC6Z2gHqakToN9vKlTVCFkSVjAfeMeh2fY0916tHwJHeeKs28qB/hGYvKuampGYH5QDVCw==",
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.isequal": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
-            "integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.orderby": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.orderby/-/lodash.orderby-4.6.6.tgz",
-            "integrity": "sha512-wQzu6xK+bSwhu45OeMI7fjywiIZiiaBzJB8W3fwnF1SJXHoOXRLutrSnVmq4yHPOM036qsy8lx9wHQcAbXNjJw==",
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.without": {
-            "version": "4.4.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.without/-/lodash.without-4.4.6.tgz",
-            "integrity": "sha512-JkPlFMcerd1ZcPtVXTi9NZsFhRk7g/rlctGYxR+Bdp/5FxqFTeTa68eJuoeuifpcLCj9ASFSHuNf7kaq5Mu9iA==",
-            "requires": {
-                "@types/lodash": "*"
-            }
-        },
-        "@types/lodash.xor": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.xor/-/lodash.xor-4.5.6.tgz",
-            "integrity": "sha512-rD3zHQuR04SMUWEn6CHLGYNRHEFgakV4K9QhFFP/Ly5xdN2MWsy+gWFA4MxhY+sKKSSKjktjPVyBTo/6rUdTjA==",
-            "requires": {
-                "@types/lodash": "*"
-            }
+            "version": "4.14.176",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+            "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
         },
         "@types/long": {
             "version": "4.0.1",
@@ -34813,6 +34669,14 @@
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
                     "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug=="
                 }
+            }
+        },
+        "eslint-plugin-lodash": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-7.3.0.tgz",
+            "integrity": "sha512-FQM8HklruJzulPawX3uZqWbeyN3bQT4hjVCpFYMrWo0Hdz1qDCwp1v3JS4zjhdssAXdwCxdnyrNMCZJK70GeUQ==",
+            "requires": {
+                "lodash": "^4.17.21"
             }
         },
         "eslint-plugin-markdown": {
@@ -40213,16 +40077,6 @@
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
         },
-        "lodash.debounce": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-        },
-        "lodash.deburr": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-            "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s="
-        },
         "lodash.defaults": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -40232,11 +40086,6 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
             "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-        },
-        "lodash.escaperegexp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-            "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
         },
         "lodash.flatten": {
             "version": "4.4.0",
@@ -40257,11 +40106,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
         },
         "lodash.isinteger": {
             "version": "4.0.4",
@@ -40310,11 +40154,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-        },
-        "lodash.orderby": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.orderby/-/lodash.orderby-4.6.0.tgz",
-            "integrity": "sha1-5pfwTOXXhSL1TZM4syuBozk+TrM="
         },
         "lodash.snakecase": {
             "version": "4.1.1",
@@ -40365,16 +40204,6 @@
             "requires": {
                 "lodash.keys": "~2.4.1"
             }
-        },
-        "lodash.without": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-            "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
-        },
-        "lodash.xor": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.xor/-/lodash.xor-4.5.0.tgz",
-            "integrity": "sha1-TUjtfpgJWwYyWCunFNP/iuj7HbY="
         },
         "log-symbols": {
             "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,7 @@
         "@react-aria/overlays": "3.7.2",
         "@types/jest": "27.0.2",
         "@types/linkify-it": "3.0.2",
-        "@types/lodash.debounce": "4.0.6",
-        "@types/lodash.deburr": "4.1.6",
-        "@types/lodash.escaperegexp": "4.1.6",
-        "@types/lodash.isequal": "4.5.5",
-        "@types/lodash.orderby": "4.6.6",
-        "@types/lodash.without": "4.4.6",
-        "@types/lodash.xor": "4.5.6",
+        "@types/lodash": "4.14.176",
         "@types/mdx": "2.0.1",
         "@types/mdx-js__react": "1.5.5",
         "@types/node": "16.11.7",
@@ -28,19 +22,14 @@
         "@types/webpack-env": "1.16.3",
         "babel-loader": "8.1.0",
         "clsx": "1.1.1",
+        "eslint-plugin-lodash": "7.3.0",
         "eslint-plugin-mdx": "1.16.0",
         "firebase": "9.4.1",
         "firebase-tools": "9.22.0",
         "i18next": "20.6.1",
         "i18next-browser-languagedetector": "6.1.2",
         "linkify-it": "3.0.3",
-        "lodash.debounce": "4.0.8",
-        "lodash.deburr": "4.1.0",
-        "lodash.escaperegexp": "4.1.2",
-        "lodash.isequal": "4.5.0",
-        "lodash.orderby": "4.6.0",
-        "lodash.without": "4.4.0",
-        "lodash.xor": "4.5.0",
+        "lodash": "4.17.21",
         "prettier": "2.2.1",
         "rc-tooltip": "5.1.1",
         "react": "17.0.2",
@@ -65,6 +54,9 @@
         "format": "prettier --write ."
     },
     "eslintConfig": {
+        "plugins": [
+            "lodash"
+        ],
         "extends": [
             "react-app",
             "react-app/jest",
@@ -73,6 +65,12 @@
         "settings": {
             "mdx/code-blocks": true,
             "mdx/language-mapper": {}
+        },
+        "rules": {
+            "lodash/import-scope": [
+                2,
+                "method"
+            ]
         },
         "overrides": [
             {

--- a/src/components/ContentItemList/index.tsx
+++ b/src/components/ContentItemList/index.tsx
@@ -1,4 +1,4 @@
-import orderBy from 'lodash.orderby';
+import orderBy from 'lodash/orderBy';
 import {
     CommentItemLinkWrapper,
     TermItemLinkWrapper,

--- a/src/components/EditVariants/index.tsx
+++ b/src/components/EditVariants/index.tsx
@@ -1,4 +1,4 @@
-import { without } from 'lodash';
+import without from 'lodash/without';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DocReference, Term, Translation } from '../../types';

--- a/src/components/SelectTooltip/index.tsx
+++ b/src/components/SelectTooltip/index.tsx
@@ -1,4 +1,4 @@
-import debounce from 'lodash.debounce';
+import debounce from 'lodash/debounce';
 import Tooltip from 'rc-tooltip';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';

--- a/src/components/TextWithHighlights/index.tsx
+++ b/src/components/TextWithHighlights/index.tsx
@@ -1,4 +1,4 @@
-import escapeRegExp from 'lodash.escaperegexp';
+import escapeRegExp from 'lodash/escapeRegExp';
 import { memo } from 'react';
 import { Redact } from '../RedactSensitiveTerms';
 

--- a/src/components/TranslationsList/service.ts
+++ b/src/components/TranslationsList/service.ts
@@ -1,5 +1,5 @@
-import deburr from 'lodash.deburr';
-import orderBy from 'lodash.orderby';
+import deburr from 'lodash/deburr';
+import orderBy from 'lodash/orderBy';
 import { Translation } from '../../types';
 
 export const sortTranslations = (translations: Translation[]) =>

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -1,5 +1,5 @@
 import firebase from 'firebase/compat/app';
-import isEqual from 'lodash.isequal';
+import isEqual from 'lodash/isEqual';
 import { DependencyList, useEffect, useMemo, useState } from 'react';
 import { ERROR_NOT_FOUND } from '../constants';
 

--- a/src/pages/TermPage/index.tsx
+++ b/src/pages/TermPage/index.tsx
@@ -1,5 +1,5 @@
 import firebase from 'firebase/compat/app';
-import xor from 'lodash.xor';
+import xor from 'lodash/xor';
 import { Suspense, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';


### PR DESCRIPTION
& add eslint plugin to enforce it for the future. This is the recommended way, since [per-method-packages are deprecated](https://lodash.com/per-method-packages).