### PR TITLE
Deploy: serve static files from a cloud storage bucket

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -40,6 +40,14 @@ jobs:
               with:
                   name: app-build
                   path: build
+            - name: Deploy static files
+              uses: actions-hub/gcloud@master
+              env:
+                  PROJECT_ID: ${{ secrets.FIREBASE_PROJECT }}
+                  APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+              with:
+                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -z js,svg,css ./build/* gs://macht-sprache-static-assets/static
+                  cli: gsutil
             - name: Get Deploy Channel ID
               run: echo ::set-output name=short::${GITHUB_REF#refs/*/}
               id: ref

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -27,6 +27,7 @@ jobs:
                   REACT_APP_FIREBASE_SENDER_ID: ${{ secrets.FIREBASE_SENDER_ID }}
                   REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
                   REACT_APP_FIREBASE_REGION: ${{ secrets.FIREBASE_REGION }}
+                  PUBLIC_URL: https://storage.googleapis.com/macht-sprache-static-assets/
             - uses: actions/upload-artifact@v2
               with:
                   name: app-build
@@ -46,7 +47,7 @@ jobs:
                   PROJECT_ID: ${{ secrets.FIREBASE_PROJECT }}
                   APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
               with:
-                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -z js,svg,css ./build/* gs://macht-sprache-static-assets/static
+                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -z js,svg,css ./build/static/* gs://macht-sprache-static-assets/static
                   cli: gsutil
             - name: Get Deploy Channel ID
               run: echo ::set-output name=short::${GITHUB_REF#refs/*/}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -47,7 +47,7 @@ jobs:
                   PROJECT_ID: ${{ secrets.FIREBASE_PROJECT }}
                   APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
               with:
-                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -z js,svg,css ./build/static/* gs://macht-sprache-static-assets/static
+                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -r -z js,svg,css ./build/static/* gs://macht-sprache-static-assets/static
                   cli: gsutil
             - name: Get Deploy Channel ID
               run: echo ::set-output name=short::${GITHUB_REF#refs/*/}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -27,7 +27,7 @@ jobs:
                   REACT_APP_FIREBASE_SENDER_ID: ${{ secrets.FIREBASE_SENDER_ID }}
                   REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
                   REACT_APP_FIREBASE_REGION: ${{ secrets.FIREBASE_REGION }}
-                  PUBLIC_URL: https://storage.googleapis.com/macht-sprache-static-assets/
+                  PUBLIC_URL: https://storage.googleapis.com/${{ secrets.STATIC_FILE_BUCKET }}/
             - uses: actions/upload-artifact@v2
               with:
                   name: app-build
@@ -46,8 +46,9 @@ jobs:
               env:
                   PROJECT_ID: ${{ secrets.FIREBASE_PROJECT }}
                   APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+                  STATIC_FILE_BUCKET: ${{ secrets.STATIC_FILE_BUCKET }}
               with:
-                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -r -z js,svg,css ./build/static/* gs://macht-sprache-static-assets/static
+                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -r -z js,svg,css ./build/static/* 'gs://'"$STATIC_FILE_BUCKET"'/static'
                   cli: gsutil
             - name: Get Deploy Channel ID
               run: echo ::set-output name=short::${GITHUB_REF#refs/*/}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -48,7 +48,7 @@ jobs:
                   APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
                   STATIC_FILE_BUCKET: ${{ secrets.STATIC_FILE_BUCKET }}
               with:
-                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -r -z js,svg,css ./build/static/* 'gs://'"$STATIC_FILE_BUCKET"'/static'
+                  args: -h 'Cache-Control:public, max-age=31536000' -m cp -n -r -z js,svg,css ./build/static 'gs://'"$STATIC_FILE_BUCKET"'/'
                   cli: gsutil
             - name: Get Deploy Channel ID
               run: echo ::set-output name=short::${GITHUB_REF#refs/*/}

--- a/firebase.json
+++ b/firebase.json
@@ -5,20 +5,20 @@
     },
     "hosting": {
         "public": "build",
-        "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+        "ignore": ["**/static/**"],
         "rewrites": [
             {
-                "source": "!/static/**",
+                "source": "**",
                 "destination": "/index.html"
             }
         ],
         "headers": [
             {
-                "source": "/static/**/*.@(css|js|map|svg|png)",
+                "source": "**",
                 "headers": [
                     {
                         "key": "Cache-Control",
-                        "value": "max-age=31536000"
+                        "value": "no-cache, public"
                     }
                 ]
             }

--- a/public/index.html
+++ b/public/index.html
@@ -2,23 +2,29 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <link rel="icon" href="%PUBLIC_URL%/favicon.png" sizes="any" type="image/png" id="faviconSvg" />
-        <link rel="icon" href="%PUBLIC_URL%/favicon.svg" sizes="any" type="image/svg+xml" id="faviconPng" />
+        <link rel="icon" href="/favicon.png" sizes="any" type="image/png" id="faviconSvg" />
+        <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" id="faviconPng" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#fff" />
-        <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
+        <!-- <link rel="apple-touch-icon" href="/logo192.png" /> -->
 
-        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+        <link rel="manifest" href="/manifest.json" />
 
         <title>macht.sprache.</title>
         <meta name="og:title" content="macht.sprache." />
 
-        <meta name="description" content="Platform to collect and discuss sensitive terms and their translations between English & German. macht.sprache. aims to develop discussion culture around discriminatory language & increase awareness for problems surrounding politically loaded terminology & (machine) translation." />
+        <meta
+            name="description"
+            content="Platform to collect and discuss sensitive terms and their translations between English & German. macht.sprache. aims to develop discussion culture around discriminatory language & increase awareness for problems surrounding politically loaded terminology & (machine) translation."
+        />
 
         <meta name="og:image" content="https://machtsprache.de/og_image.png" />
 
         <meta name="twitter:title" content="macht.sprache." />
-        <meta name="twitter:description" content="Platform to collect and discuss sensitive terms and their translations between English & German. macht.sprache. aims to develop discussion culture around discriminatory language & increase awareness for problems surrounding politically loaded terminology & (machine) translation." />
+        <meta
+            name="twitter:description"
+            content="Platform to collect and discuss sensitive terms and their translations between English & German. macht.sprache. aims to develop discussion culture around discriminatory language & increase awareness for problems surrounding politically loaded terminology & (machine) translation."
+        />
         <meta name="twitter:image" content="https://machtsprache.de/og_image.png" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@poco_lit" />


### PR DESCRIPTION
With the manifesto we're making more use of code splitting, so we now need to ensure that files stay around even after we do another deploy. This doesn't seem possible with firebase hosting, so we're serving static files from a cloud storage bucket now.